### PR TITLE
feat(identity): persist webauthn challenges and add tests

### DIFF
--- a/smartedify_app/services/support/identity-service/src/modules/webauthn/webauthn.controller.ts
+++ b/smartedify_app/services/support/identity-service/src/modules/webauthn/webauthn.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Get, Query } from '@nestjs/common';
+import { Body, Controller, Get, Headers, Post, Query } from '@nestjs/common';
 import { WebauthnService } from './webauthn.service';
 
 @Controller('webauthn')
@@ -13,9 +13,10 @@ export class WebauthnController {
   @Post('registration/verification')
   async registrationVerification(
     @Body() body: any,
-    @Body('userId') userId: string
+    @Body('userId') userId: string,
+    @Headers('webauthn-challenge') challenge?: string,
   ) {
-    return this.webauthnService.verifyRegistration(body, userId);
+    return this.webauthnService.verifyRegistration(body, userId, challenge);
   }
 
   @Get('authentication/options')
@@ -26,8 +27,8 @@ export class WebauthnController {
   @Post('authentication/verification')
   async authenticationVerification(
     @Body() body: any,
-    @Body('username') username: string
+    @Headers('webauthn-challenge') challenge?: string,
   ) {
-    return this.webauthnService.verifyAuthentication(body, username);
+    return this.webauthnService.verifyAuthentication(body, challenge);
   }
 }

--- a/smartedify_app/services/support/identity-service/src/modules/webauthn/webauthn.service.ts
+++ b/smartedify_app/services/support/identity-service/src/modules/webauthn/webauthn.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import {
   generateRegistrationOptions,
   verifyRegistrationResponse,
@@ -13,13 +13,72 @@ import { WebAuthnCredential } from './entities/webauthn-credential.entity';
 import { Repository } from 'typeorm';
 
 @Injectable()
+type ChallengeType = 'registration' | 'authentication';
+
+interface StoredChallenge {
+  challenge: string;
+  expiresAt: number;
+}
+
 export class WebauthnService {
+  private readonly challengeTtlMs = 1000 * 60 * 5; // 5 minutes
+  private readonly challengeStore = new Map<string, StoredChallenge>();
+
   constructor(
     private readonly rpService: RpService,
     private readonly usersService: UsersService,
     @InjectRepository(WebAuthnCredential)
     private webAuthnCredentialRepository: Repository<WebAuthnCredential>,
   ) {}
+
+  private getChallengeKey(type: ChallengeType, subjectId: string): string {
+    return `${type}:${subjectId}`;
+  }
+
+  private setChallenge(type: ChallengeType, subjectId: string, challenge: string): void {
+    const key = this.getChallengeKey(type, subjectId);
+    this.challengeStore.set(key, {
+      challenge,
+      expiresAt: Date.now() + this.challengeTtlMs,
+    });
+  }
+
+  private getChallenge(type: ChallengeType, subjectId: string): string | null {
+    const key = this.getChallengeKey(type, subjectId);
+    const stored = this.challengeStore.get(key);
+
+    if (!stored) {
+      return null;
+    }
+
+    if (stored.expiresAt <= Date.now()) {
+      this.challengeStore.delete(key);
+      return null;
+    }
+
+    return stored.challenge;
+  }
+
+  private deleteChallenge(type: ChallengeType, subjectId: string): void {
+    const key = this.getChallengeKey(type, subjectId);
+    this.challengeStore.delete(key);
+  }
+
+  private toBuffer(value: Buffer | Uint8Array | string, encoding: BufferEncoding | 'base64url' = 'base64url'): Buffer {
+    if (Buffer.isBuffer(value)) {
+      return Buffer.from(value);
+    }
+
+    if (value instanceof Uint8Array) {
+      return Buffer.from(value);
+    }
+
+    if (encoding === 'base64url') {
+      return Buffer.from(value, 'base64url');
+    }
+
+    return Buffer.from(value, encoding);
+  }
 
   async generateRegistrationOptions(username: string) {
     const user = await this.usersService.findByEmail(username);
@@ -46,41 +105,57 @@ export class WebauthnService {
       },
     });
 
-    // In a real implementation, we would store the challenge
-    // await this.challengeStore.set(user.id, options.challenge);
+    if (options.challenge) {
+      this.setChallenge('registration', user.id, options.challenge);
+    }
 
     return options;
   }
 
-  async verifyRegistration(response: any, expectedChallenge: string) {
+  async verifyRegistration(response: any, userId: string, providedChallenge: string) {
+    if (!userId) {
+      throw new BadRequestException('User identifier is required');
+    }
+
+    if (!providedChallenge) {
+      throw new BadRequestException('Registration challenge is required');
+    }
+
+    const storedChallenge = this.getChallenge('registration', userId);
+    if (!storedChallenge || storedChallenge !== providedChallenge) {
+      throw new BadRequestException('Invalid or expired registration challenge');
+    }
+
     const verification = await verifyRegistrationResponse({
       response,
-      expectedChallenge,
+      expectedChallenge: storedChallenge,
       expectedOrigin: this.rpService.getExpectedOrigin(),
       expectedRPID: this.rpService.getRpId(),
     });
 
     if (verification.verified && verification.registrationInfo) {
-      // Access properties directly from verification.registrationInfo as per SimpleWebAuthn docs
-      // @ts-ignore: Property 'credential' does not exist on type 'RegistrationInfo'.
-      const { credentialPublicKey, credentialID, counter } = verification.registrationInfo; // Corrected access
+      const { credentialPublicKey, credentialID, counter } = verification.registrationInfo as {
+        credentialPublicKey: Uint8Array | Buffer;
+        credentialID: Uint8Array | Buffer;
+        counter: number;
+      };
 
-      // In a real implementation, we would get the user from the session
-      const user = await this.usersService.findByEmail('test@test.com'); // placeholder
+      const user = await this.usersService.findById(userId);
       if (!user) {
         throw new NotFoundException('User not found');
       }
 
       const newCredential = this.webAuthnCredentialRepository.create({
         user,
-        credential_id: credentialID,
-        public_key: credentialPublicKey,
+        credential_id: this.toBuffer(credentialID, 'base64url'),
+        public_key: this.toBuffer(credentialPublicKey, 'base64url'),
         sign_count: counter,
         rp_id: this.rpService.getRpId(),
         origin: this.rpService.getExpectedOrigin(),
         // transports: response.response.transports, // This needs to be handled correctly
       });
       await this.webAuthnCredentialRepository.save(newCredential);
+      this.deleteChallenge('registration', userId);
     }
 
     return verification;
@@ -88,8 +163,9 @@ export class WebauthnService {
 
   async generateAuthenticationOptions(username?: string) {
     let allowCredentials;
+    let user;
     if (username) {
-        const user = await this.usersService.findByEmail(username);
+        user = await this.usersService.findByEmail(username);
         if (user) {
             const userCredentials = await this.webAuthnCredentialRepository.find({ where: { user: { id: user.id } } });
             allowCredentials = userCredentials.map(cred => ({
@@ -106,25 +182,43 @@ export class WebauthnService {
       allowCredentials,
     });
 
-    // In a real implementation, we would store the challenge
-    // await this.challengeStore.set('current-challenge', options.challenge);
+    if (user && options.challenge) {
+      this.setChallenge('authentication', user.id, options.challenge);
+    }
 
     return options;
   }
 
-  async verifyAuthentication(response: any, expectedChallenge: string) {
-    const { credentialID } = response;
-    const credential = await this.webAuthnCredentialRepository.findOne({ where: { credential_id: credentialID } });
+  async verifyAuthentication(response: any, providedChallenge: string) {
+    if (!providedChallenge) {
+      throw new BadRequestException('Authentication challenge is required');
+    }
+
+    const credentialIdSource = response.credentialID || response.id || response.rawId;
+    if (!credentialIdSource) {
+      throw new BadRequestException('Credential ID is required');
+    }
+
+    const credentialIdBuffer = this.toBuffer(credentialIdSource, 'base64url');
+    const credential = await this.webAuthnCredentialRepository.findOne({
+      where: { credential_id: credentialIdBuffer },
+      relations: ['user'],
+    });
 
     if (!credential) {
         throw new NotFoundException('Credential not found');
+    }
+
+    const storedChallenge = this.getChallenge('authentication', credential.user.id);
+    if (!storedChallenge || storedChallenge !== providedChallenge) {
+      throw new BadRequestException('Invalid or expired authentication challenge');
     }
 
     // @ts-ignore: The library's type definition for verifyAuthenticationResponse might be outdated or strict.
     const verification = await verifyAuthenticationResponse(
       {
         response,
-        expectedChallenge,
+        expectedChallenge: storedChallenge,
         expectedOrigin: this.rpService.getExpectedOrigin(),
         expectedRPID: this.rpService.getRpId(),
         credential: {
@@ -138,7 +232,9 @@ export class WebauthnService {
 
     if (verification.verified) {
         credential.sign_count = verification.authenticationInfo.newCounter;
+        credential.last_used_at = new Date();
         await this.webAuthnCredentialRepository.save(credential);
+        this.deleteChallenge('authentication', credential.user.id);
     }
 
     return verification;

--- a/smartedify_app/services/support/identity-service/test/webauthn.e2e-spec.ts
+++ b/smartedify_app/services/support/identity-service/test/webauthn.e2e-spec.ts
@@ -1,15 +1,35 @@
-
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
-import { TestConfigurationFactory, TestModuleSetup, TEST_CONSTANTS, TestTimeoutManager } from './utils/test-configuration.factory';
+import { Repository } from 'typeorm';
+import {
+  generateAuthenticationOptions,
+  generateRegistrationOptions,
+  verifyAuthenticationResponse,
+  verifyRegistrationResponse,
+} from '@simplewebauthn/server';
+import {
+  TestConfigurationFactory,
+  TestModuleSetup,
+  TEST_CONSTANTS,
+  TestTimeoutManager,
+} from './utils/test-configuration.factory';
 import { UsersService } from '../src/modules/users/users.service';
 import { User } from '../src/modules/users/entities/user.entity';
+import { WebAuthnCredential } from '../src/modules/webauthn/entities/webauthn-credential.entity';
+
+jest.mock('@simplewebauthn/server', () => ({
+  generateRegistrationOptions: jest.fn(),
+  verifyRegistrationResponse: jest.fn(),
+  generateAuthenticationOptions: jest.fn(),
+  verifyAuthenticationResponse: jest.fn(),
+}));
 
 describe('WebAuthn (e2e)', () => {
   let setup: TestModuleSetup;
   let app: INestApplication;
   let usersService: UsersService;
   let testUser: User;
+  let credentialsRepository: Repository<WebAuthnCredential>;
 
   beforeAll(async () => {
     setup = await TestTimeoutManager.withTimeout(
@@ -19,10 +39,12 @@ describe('WebAuthn (e2e)', () => {
     );
     app = setup.app;
     usersService = setup.usersService;
+    credentialsRepository = setup.webAuthnCredentialsRepository;
     await app.listen(0);
   }, TEST_CONSTANTS.TEST_TIMEOUT);
 
   beforeEach(async () => {
+    jest.resetAllMocks();
     await TestTimeoutManager.withTimeout(
       () => TestConfigurationFactory.cleanDatabase(setup),
       TEST_CONSTANTS.DATABASE_OPERATION_TIMEOUT,
@@ -47,10 +69,22 @@ describe('WebAuthn (e2e)', () => {
 
   describe('Options Generation', () => {
     it('should return valid registration options', async () => {
+      const expectedChallenge = 'registration-challenge';
+      (generateRegistrationOptions as jest.Mock).mockResolvedValue({
+        challenge: expectedChallenge,
+        rp: { name: 'SmartEdify', id: 'smartedify.local' },
+        user: {
+          id: Buffer.from(testUser.id).toString('base64url'),
+          name: testUser.email,
+          displayName: testUser.email,
+        },
+        pubKeyCredParams: [],
+      });
+
       const response = await request(app.getHttpServer())
         .get('/webauthn/registration/options')
         .query({ username: testUser.email, userId: testUser.id });
-      
+
       expect(response.status).toBe(200);
       expect(response.body).toBeDefined();
       expect(response.body.rp).toBeDefined();
@@ -61,13 +95,317 @@ describe('WebAuthn (e2e)', () => {
     });
 
     it('should return valid authentication options', async () => {
+        const expectedChallenge = 'authentication-challenge';
+        (generateRegistrationOptions as jest.Mock).mockResolvedValue({
+          challenge: 'registration-challenge',
+          rp: { name: 'SmartEdify', id: 'smartedify.local' },
+          user: {
+            id: Buffer.from(testUser.id).toString('base64url'),
+            name: testUser.email,
+            displayName: testUser.email,
+          },
+          pubKeyCredParams: [],
+        });
+
+        (generateAuthenticationOptions as jest.Mock).mockResolvedValue({
+          challenge: expectedChallenge,
+          allowCredentials: [],
+        });
+
+        await request(app.getHttpServer())
+          .get('/webauthn/registration/options')
+          .query({ username: testUser.email, userId: testUser.id });
+
         const response = await request(app.getHttpServer())
           .get('/webauthn/authentication/options')
           .query({ username: testUser.email });
-        
+
         expect(response.status).toBe(200);
         expect(response.body).toBeDefined();
         expect(response.body.challenge).toBeDefined();
+        expect(response.body.challenge).toBe(expectedChallenge);
       });
+  });
+
+  describe('Verification', () => {
+    it('should verify registration with stored challenge and persist credential', async () => {
+      const registrationChallenge = 'registration-challenge';
+      const credentialId = Buffer.from('credential-id');
+
+      (generateRegistrationOptions as jest.Mock).mockResolvedValue({
+        challenge: registrationChallenge,
+        rp: { name: 'SmartEdify', id: 'smartedify.local' },
+        user: {
+          id: Buffer.from(testUser.id).toString('base64url'),
+          name: testUser.email,
+          displayName: testUser.email,
+        },
+        pubKeyCredParams: [],
+      });
+
+      (verifyRegistrationResponse as jest.Mock).mockResolvedValue({
+        verified: true,
+        registrationInfo: {
+          credentialPublicKey: Buffer.from('public-key'),
+          credentialID: credentialId,
+          counter: 1,
+        },
+      });
+
+      await request(app.getHttpServer())
+        .get('/webauthn/registration/options')
+        .query({ username: testUser.email });
+
+      const webauthnResponse = {
+        id: credentialId.toString('base64url'),
+        rawId: credentialId.toString('base64url'),
+        response: {},
+        type: 'public-key',
+        clientExtensionResults: {},
+        authenticatorAttachment: 'cross-platform',
+        userId: testUser.id,
+      };
+
+      const verificationResponse = await request(app.getHttpServer())
+        .post('/webauthn/registration/verification')
+        .set('webauthn-challenge', registrationChallenge)
+        .send(webauthnResponse);
+
+      expect(verificationResponse.status).toBe(201);
+      expect(verifyRegistrationResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ expectedChallenge: registrationChallenge })
+      );
+
+      const credentials = await credentialsRepository.find({
+        where: { user: { id: testUser.id } },
+        relations: ['user'],
+      });
+      expect(credentials).toHaveLength(1);
+      expect(credentials[0].user.id).toBe(testUser.id);
+    });
+
+    it('should reject registration verification when challenge is reused', async () => {
+      const registrationChallenge = 'registration-challenge';
+      const credentialId = Buffer.from('credential-id');
+
+      (generateRegistrationOptions as jest.Mock).mockResolvedValue({
+        challenge: registrationChallenge,
+        rp: { name: 'SmartEdify', id: 'smartedify.local' },
+        user: {
+          id: Buffer.from(testUser.id).toString('base64url'),
+          name: testUser.email,
+          displayName: testUser.email,
+        },
+        pubKeyCredParams: [],
+      });
+
+      (verifyRegistrationResponse as jest.Mock).mockResolvedValue({
+        verified: true,
+        registrationInfo: {
+          credentialPublicKey: Buffer.from('public-key'),
+          credentialID: credentialId,
+          counter: 1,
+        },
+      });
+
+      await request(app.getHttpServer())
+        .get('/webauthn/registration/options')
+        .query({ username: testUser.email });
+
+      const payload = {
+        id: credentialId.toString('base64url'),
+        rawId: credentialId.toString('base64url'),
+        response: {},
+        type: 'public-key',
+        clientExtensionResults: {},
+        authenticatorAttachment: 'cross-platform',
+        userId: testUser.id,
+      };
+
+      const firstAttempt = await request(app.getHttpServer())
+        .post('/webauthn/registration/verification')
+        .set('webauthn-challenge', registrationChallenge)
+        .send(payload);
+      expect(firstAttempt.status).toBe(201);
+
+      const secondAttempt = await request(app.getHttpServer())
+        .post('/webauthn/registration/verification')
+        .set('webauthn-challenge', registrationChallenge)
+        .send(payload);
+
+      expect(secondAttempt.status).toBe(400);
+      expect(verifyRegistrationResponse).toHaveBeenCalledTimes(1);
+    });
+
+    it('should verify authentication using stored challenge and credential', async () => {
+      const registrationChallenge = 'registration-challenge';
+      const authenticationChallenge = 'authentication-challenge';
+      const credentialId = Buffer.from('credential-id');
+
+      (generateRegistrationOptions as jest.Mock).mockResolvedValue({
+        challenge: registrationChallenge,
+        rp: { name: 'SmartEdify', id: 'smartedify.local' },
+        user: {
+          id: Buffer.from(testUser.id).toString('base64url'),
+          name: testUser.email,
+          displayName: testUser.email,
+        },
+        pubKeyCredParams: [],
+      });
+
+      (verifyRegistrationResponse as jest.Mock).mockResolvedValue({
+        verified: true,
+        registrationInfo: {
+          credentialPublicKey: Buffer.from('public-key'),
+          credentialID: credentialId,
+          counter: 1,
+        },
+      });
+
+      (generateAuthenticationOptions as jest.Mock).mockResolvedValue({
+        challenge: authenticationChallenge,
+        allowCredentials: [
+          {
+            id: credentialId.toString('base64url'),
+            type: 'public-key',
+          },
+        ],
+      });
+
+      (verifyAuthenticationResponse as jest.Mock).mockResolvedValue({
+        verified: true,
+        authenticationInfo: {
+          newCounter: 2,
+        },
+      });
+
+      await request(app.getHttpServer())
+        .get('/webauthn/registration/options')
+        .query({ username: testUser.email });
+
+      await request(app.getHttpServer())
+        .post('/webauthn/registration/verification')
+        .set('webauthn-challenge', registrationChallenge)
+        .send({
+          id: credentialId.toString('base64url'),
+          rawId: credentialId.toString('base64url'),
+          response: {},
+          type: 'public-key',
+          clientExtensionResults: {},
+          authenticatorAttachment: 'cross-platform',
+          userId: testUser.id,
+        });
+
+      await request(app.getHttpServer())
+        .get('/webauthn/authentication/options')
+        .query({ username: testUser.email });
+
+      const authResponse = await request(app.getHttpServer())
+        .post('/webauthn/authentication/verification')
+        .set('webauthn-challenge', authenticationChallenge)
+        .send({
+          credentialID: credentialId.toString('base64url'),
+          response: {},
+          type: 'public-key',
+        });
+
+      expect(authResponse.status).toBe(201);
+      expect(verifyAuthenticationResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ expectedChallenge: authenticationChallenge })
+      );
+
+      const storedCredential: WebAuthnCredential = await credentialsRepository.findOne({
+        where: { user: { id: testUser.id } },
+        relations: ['user'],
+      });
+      expect(storedCredential.sign_count).toBe(2);
+      expect(storedCredential.last_used_at).toBeInstanceOf(Date);
+    });
+
+    it('should reject authentication when challenge is reused', async () => {
+      const registrationChallenge = 'registration-challenge';
+      const authenticationChallenge = 'authentication-challenge';
+      const credentialId = Buffer.from('credential-id');
+
+      (generateRegistrationOptions as jest.Mock).mockResolvedValue({
+        challenge: registrationChallenge,
+        rp: { name: 'SmartEdify', id: 'smartedify.local' },
+        user: {
+          id: Buffer.from(testUser.id).toString('base64url'),
+          name: testUser.email,
+          displayName: testUser.email,
+        },
+        pubKeyCredParams: [],
+      });
+
+      (verifyRegistrationResponse as jest.Mock).mockResolvedValue({
+        verified: true,
+        registrationInfo: {
+          credentialPublicKey: Buffer.from('public-key'),
+          credentialID: credentialId,
+          counter: 1,
+        },
+      });
+
+      (generateAuthenticationOptions as jest.Mock).mockResolvedValue({
+        challenge: authenticationChallenge,
+        allowCredentials: [
+          {
+            id: credentialId.toString('base64url'),
+            type: 'public-key',
+          },
+        ],
+      });
+
+      (verifyAuthenticationResponse as jest.Mock).mockResolvedValue({
+        verified: true,
+        authenticationInfo: {
+          newCounter: 2,
+        },
+      });
+
+      await request(app.getHttpServer())
+        .get('/webauthn/registration/options')
+        .query({ username: testUser.email });
+
+      await request(app.getHttpServer())
+        .post('/webauthn/registration/verification')
+        .set('webauthn-challenge', registrationChallenge)
+        .send({
+          id: credentialId.toString('base64url'),
+          rawId: credentialId.toString('base64url'),
+          response: {},
+          type: 'public-key',
+          clientExtensionResults: {},
+          authenticatorAttachment: 'cross-platform',
+          userId: testUser.id,
+        });
+
+      await request(app.getHttpServer())
+        .get('/webauthn/authentication/options')
+        .query({ username: testUser.email });
+
+      const firstAttempt = await request(app.getHttpServer())
+        .post('/webauthn/authentication/verification')
+        .set('webauthn-challenge', authenticationChallenge)
+        .send({
+          credentialID: credentialId.toString('base64url'),
+          response: {},
+          type: 'public-key',
+        });
+      expect(firstAttempt.status).toBe(201);
+
+      const secondAttempt = await request(app.getHttpServer())
+        .post('/webauthn/authentication/verification')
+        .set('webauthn-challenge', authenticationChallenge)
+        .send({
+          credentialID: credentialId.toString('base64url'),
+          response: {},
+          type: 'public-key',
+        });
+
+      expect(secondAttempt.status).toBe(400);
+      expect(verifyAuthenticationResponse).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add an in-memory challenge store with TTL to WebAuthn registration and authentication flows
- update the WebAuthn controller to consume stored challenges via headers and use real user identifiers
- extend WebAuthn e2e tests to cover happy paths, challenge reuse prevention, and credential association

## Testing
- npx jest --config ./test/jest-e2e.json --runInBand --detectOpenHandles webauthn.e2e-spec.ts *(fails: underlying Postgres database is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68daddf26a2c832992c95d71f5395f12